### PR TITLE
Fix for null featuredImage

### DIFF
--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -42,10 +42,12 @@ export default function PageTemplate({ data }) {
               {title}
             </Typography>
           </Box>
-          <Img
-            fluid={featuredImage.childImageSharp.fluid}
-            style={{ borderRadius: 2 }}
-          />
+          { featuredImage &&
+            <Img
+              fluid={featuredImage.childImageSharp.fluid}
+              style={{ borderRadius: 2 }}
+            />
+          }
           <article className={classes.article}>
             <MDXRenderer>{body}</MDXRenderer>
           </article>


### PR DESCRIPTION
When a page doesn't provide the featuredImage attribute, an error occurs. This allows pages to not use a featuredImage attribute.